### PR TITLE
Optimize text measurement in quiz app

### DIFF
--- a/index.html
+++ b/index.html
@@ -478,6 +478,10 @@
         // =================================================================
         let dom = {};
 
+        // Canvas context for measuring text widths
+        const textMeasureCanvas = document.createElement('canvas');
+        const textMeasureCtx = textMeasureCanvas.getContext('2d');
+
         // =================================================================
         // --- 상태 (State) ---
         // =================================================================
@@ -935,11 +939,9 @@
 
         function updateInputWidth(input) {
             const computedStyle = window.getComputedStyle(input);
-            const canvas = document.createElement('canvas');
-            const ctx = canvas.getContext('2d');
-            ctx.font = `${computedStyle.fontWeight} ${computedStyle.fontSize} ${computedStyle.fontFamily}`;
+            textMeasureCtx.font = `${computedStyle.fontWeight} ${computedStyle.fontSize} ${computedStyle.fontFamily}`;
             const text = input.value || input.placeholder || " ";
-            const textMetrics = ctx.measureText(text);
+            const textMetrics = textMeasureCtx.measureText(text);
             const availableWidth = dom.questionContainer.clientWidth;
             const desiredWidth = textMetrics.width + config.INPUT_WIDTH_BUFFER;
             const newWidth = Math.max(config.INPUT_MIN_WIDTH, Math.min(desiredWidth, availableWidth - 4));


### PR DESCRIPTION
## Summary
- reuse a single canvas for measuring text
- update `updateInputWidth` to only adjust width using shared context

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686e2efa6aec832c9b1eeb012d560aa3