### PR TITLE
Add celebratory effects and outfit progression

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,14 @@
         .mouth.happy { height: 10px; width: 25px; border-bottom-left-radius: 15px; border-bottom-right-radius: 15px; border-top-left-radius: 0; border-top-right-radius: 0; background-color: #1a1a1a; transform: translateY(-3px); }
         .mouth.worried { height: 10px; width: 25px; border-top-left-radius: 15px; border-top-right-radius: 15px; border-bottom-left-radius: 0; border-bottom-right-radius: 0; background-color: #1a1a1a; transform: translateY(3px); }
         .mouth.sad { height: 10px; width: 25px; border-top-left-radius: 15px; border-top-right-radius: 15px; border-bottom-left-radius: 0; border-bottom-right-radius: 0; background-color: #1a1a1a; transform: translateY(5px); }
+/* --- Celebration Effects --- */
+        .confetti { position: fixed; top: -10px; width: 8px; height: 8px; pointer-events: none; z-index: 100; }
+        @keyframes screen-shake { 0%,100% { transform: translate(0,0); } 20%,60% { transform: translate(-5px,5px); } 40%,80% { transform: translate(5px,-5px); } }
+        .shake { animation: screen-shake 0.5s; }
+        .hat { position: absolute; top: -25px; left: 50%; transform: translateX(-50%); width: 60px; height: 20px; background: #333; border-radius: 10px 10px 0 0; }
+        .hat::after { content: ""; position: absolute; bottom: -6px; left: -10px; width: 80px; height: 8px; background: #333; border-radius: 4px; }
+        .scarf { position: absolute; bottom: -12px; left: 50%; transform: translateX(-50%); width: 80px; height: 12px; background: #e53935; border-radius: 6px; }
+
         
         /* --- 지식 지도 & 오답 노트 --- */
         .map-section, .incorrect-note-section {
@@ -500,6 +508,7 @@
                 completionStatus: {}, // 방문 시마다 진행 상태 초기화
                 incorrectNotes: loadData('quizIncorrectNotes', []),
                 currentExpression: 'normal',
+                characterOutfitStage: 0,
                 idleTimeout: null,
                 lastTypeSoundTime: 0,
                 activeInputValue: null,
@@ -831,6 +840,7 @@
             const allDisabled = Array.from(dom.questionContainer.querySelectorAll('.quiz-input')).every(i => i.disabled);
             if (allDisabled) {
                 const quiz = state.activeQuizzes[state.currentQuizIndex];
+                advanceCharacterOutfit();
                 
                 if (state.isQuestionPerfect) {
                     state.questionPerfectStatus[state.currentQuizIndex] = true;
@@ -843,6 +853,8 @@
                     const perfectNotes = ['C5', 'E5', 'G5', 'C6'];
                     sounds.perfect.triggerAttackRelease(perfectNotes, '8n', Tone.now());
                     showPerfectMessage();
+                    triggerConfetti();
+                    triggerScreenShake();
 
                     if (Math.random() < config.ROULETTE_CHANCE) {
                         setTimeout(showRoulette, 800);
@@ -979,7 +991,22 @@
                 perfectEl.addEventListener('animationend', () => perfectEl.remove());
             }, 800);
         }
-        
+
+        function triggerConfetti() {
+            for (let i = 0; i < 30; i++) {
+                const c = document.createElement("div");
+                c.className = "confetti";
+                c.style.left = `${Math.random() * window.innerWidth}px`;
+                c.style.backgroundColor = `hsl(${Math.random()*360}, 100%, 50%)`;
+                document.body.appendChild(c);
+                c.animate([{ transform: "translateY(0)", opacity: 1 }, { transform: `translateY(${window.innerHeight}px)`, opacity: 0 }], { duration: 1000 + Math.random()*500, easing: "ease-out" }).onfinish = () => c.remove();
+            }
+        }
+
+        function triggerScreenShake() {
+            document.body.classList.add("shake");
+            setTimeout(() => document.body.classList.remove("shake"), 500);
+        }
         function showToast(message) {
             const toast = dom.reviewToast;
             toast.textContent = message;
@@ -1159,6 +1186,27 @@
                 dom.characterBody.classList.add('level-2');
                 dom.characterBody.style.setProperty('--scale', 1.1);
             }
+        }
+
+        function updateCharacterOutfit() {
+            const extras = dom.characterBody.querySelectorAll(".hat, .scarf");
+            extras.forEach(e => e.remove());
+            if (state.characterOutfitStage >= 1) {
+                const hat = document.createElement("div");
+                hat.className = "hat";
+                dom.characterBody.appendChild(hat);
+            }
+            if (state.characterOutfitStage >= 2) {
+                const scarf = document.createElement("div");
+                scarf.className = "scarf";
+                dom.characterBody.appendChild(scarf);
+            }
+        }
+
+        function advanceCharacterOutfit() {
+            state.characterOutfitStage = (state.characterOutfitStage || 0) + 1;
+            if (state.characterOutfitStage > 2) state.characterOutfitStage = 2;
+            updateCharacterOutfit();
         }
 
         // =================================================================
@@ -1375,6 +1423,7 @@
             renderKnowledgeMap();
             updateCharacterGrowth();
             updateIncorrectNoteButton();
+            updateCharacterOutfit();
             updateMoneyUI();
             
             const allButtons = document.querySelectorAll('button');


### PR DESCRIPTION
## Summary
- add screen shake and confetti effects for correct answers
- introduce simple hat and scarf outfits for the mascot
- grow outfit stage when each question is solved
- initialise outfit stage in global state and update on load

## Testing
- `wc -l index.html`

------
https://chatgpt.com/codex/tasks/task_e_686e2fe762b8832cbb0ffaccd36286c0