### PR TITLE
Add random cat animation on correct answers

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,13 @@
         @keyframes score-up { 0% { transform: translateY(0) scale(1); opacity: 1; } 100% { transform: translateY(-30px) scale(1.5); opacity: 0; } }
         .score-up-animation { position: absolute; font-weight: bold; animation: score-up 0.8s ease-out; pointer-events: none; }
 
+        /* --- Cat walk animation --- */
+        @keyframes cat-walk-right { from { left: -10%; } to { left: 110%; } }
+        @keyframes cat-walk-left { from { left: 110%; transform: scaleX(-1); } to { left: -10%; transform: scaleX(-1); } }
+        .cat { position: fixed; bottom: 10%; font-size: 3rem; pointer-events: none; z-index: 50; }
+        .cat-right { animation: cat-walk-right 6s linear forwards; }
+        .cat-left { animation: cat-walk-left 6s linear forwards; }
+
         @keyframes perfect-pop { 0% { transform: scale(0.5); opacity: 0; } 60% { transform: scale(1.2); opacity: 1; } 100% { transform: scale(1); opacity: 1; } }
         @keyframes perfect-fade-out { 0% { transform: scale(1); opacity: 1; } 100% { transform: scale(1.5); opacity: 0; } }
         .perfect-message {
@@ -791,6 +798,7 @@
         
         function handleCorrectAnswer(input) {
             setCharExpression('happy');
+            spawnCat();
 
             sounds.coin.triggerAttackRelease('B5', '16n', Tone.now());
             
@@ -1014,6 +1022,18 @@
                 toast.classList.remove('opacity-100', 'translate-y-0');
                 toast.classList.add('opacity-0', 'translate-y-10');
             }, 2000);
+        }
+
+        function spawnCat() {
+            const cats = ['🐱','😺','😸','😹','😻','😼','😽'];
+            const catEl = document.createElement('div');
+            catEl.className = 'cat';
+            catEl.textContent = cats[Math.floor(Math.random() * cats.length)];
+            const dirRight = Math.random() < 0.5;
+            catEl.classList.add(dirRight ? 'cat-right' : 'cat-left');
+            catEl.style.bottom = (Math.random() * 20 + 5) + '%';
+            document.body.appendChild(catEl);
+            catEl.addEventListener('animationend', () => catEl.remove());
         }
 
         // =================================================================


### PR DESCRIPTION
## Summary
- add walking cat animations using emoji
- show a random cat every time a blank is answered correctly

## Testing
- `node -e "const q=require('./data/quizzes.json');console.log('loaded', q.length);"`

------
https://chatgpt.com/codex/tasks/task_e_6872017b0218832c83bbd6a321289aa9