### PR TITLE
Fix star color update in knowledge map

### DIFF
--- a/index.html
+++ b/index.html
@@ -1113,7 +1113,9 @@ function setCharExpression(type) {
                 const svg = iconContainer.querySelector('svg');
                 svg.classList.add(status);
                 const color = STAR_COLORS[index % STAR_COLORS.length];
-                svg.style.setProperty('--star-color', color);
+                if (status === 'completed' || status === 'perfect') {
+                    svg.style.setProperty('--star-color', color);
+                }
 
                 const label = document.createElement('div');
                 label.className = 'star-label';


### PR DESCRIPTION
## Summary
- only apply `--star-color` style when a section is completed or perfect

## Testing
- `npm test` *(fails: ENOENT could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687219f65ce8832cbf8357fcbf57543d