### PR TITLE
docs: clarify running with local server

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,17 @@ This project contains a single-page quiz application. Quiz data is stored separa
 ```
 
 All quiz categories are listed in this array. The application loads this file during initialization to populate the `allQuizzes` array used throughout the game.
+
+## Running locally
+
+The quiz loads `data/quizzes.json` via HTTP. Opening `index.html` directly
+with a `file://` URL will prevent this fetch from working. Instead, start a
+simple HTTP server from the project root and then navigate to it in your
+browser:
+
+```bash
+python3 -m http.server
+```
+
+After running the command above, open <http://localhost:8000/> and the app will
+be able to fetch the quiz data correctly.


### PR DESCRIPTION
## Summary
- document how to launch a simple HTTP server for loading quiz data
- note that loading `index.html` via `file://` won't work

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687253793100832cb23759b51184a421